### PR TITLE
[11.0] [IMP] oxigen_mrp_repair

### DIFF
--- a/oxigen_mrp_repair/i18n/es.po
+++ b/oxigen_mrp_repair/i18n/es.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* oxigen_mrp_repair
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-10 12:52+0000\n"
+"PO-Revision-Date: 2021-11-10 12:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: oxigen_mrp_repair
+#: model:ir.model.fields,field_description:oxigen_mrp_repair.field_mrp_repair_distance_km
+msgid "Kilometers"
+msgstr "Kilómetros"
+
+#. module: oxigen_mrp_repair
+#: model:ir.model.fields,field_description:oxigen_mrp_repair.field_mrp_repair_list_date
+msgid "Lists date"
+msgstr "Fecha de listas"
+
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:33
+#, python-format
+msgid "Cannot delete a finished Repair Order."
+msgstr "No se puede borrar una orden de reparación finalizada."
+
+#. module: oxigen_mrp_repair
+#: model:ir.model,name:oxigen_mrp_repair.model_mrp_repair
+msgid "Repair Order"
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:27
+#, python-format
+msgid "Repair must be canceled in order to reset it to draft."
+msgstr "La reparación tiene que estar cancelada para poder volver a borrador"
+
+#. module: oxigen_mrp_repair
+#: model:ir.ui.view,arch_db:oxigen_mrp_repair.view_repair_order_form
+msgid "Set to Draft"
+msgstr "Volver a borrador"
+

--- a/oxigen_mrp_repair/i18n/oxigen_mrp_repair.pot
+++ b/oxigen_mrp_repair/i18n/oxigen_mrp_repair.pot
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* oxigen_mrp_repair
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-10 12:52+0000\n"
+"PO-Revision-Date: 2021-11-10 12:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: oxigen_mrp_repair
+#: model:ir.model.fields,field_description:oxigen_mrp_repair.field_mrp_repair_kilometers
+msgid "Kilometers"
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: model:ir.model.fields,field_description:oxigen_mrp_repair.field_mrp_repair_lists_date
+msgid "Lists date"
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:33
+#, python-format
+msgid "No se puede borrar una orden de reparación finalizada."
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: model:ir.model,name:oxigen_mrp_repair.model_mrp_repair
+msgid "Repair Order"
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:27
+#, python-format
+msgid "Repair must be canceled in order to reset it to draft."
+msgstr ""
+
+#. module: oxigen_mrp_repair
+#: model:ir.ui.view,arch_db:oxigen_mrp_repair.view_repair_order_form
+msgid "Set to Draft"
+msgstr ""
+

--- a/oxigen_mrp_repair/models/mrp_repair.py
+++ b/oxigen_mrp_repair/models/mrp_repair.py
@@ -9,16 +9,35 @@ class OxigenRepair(models.Model):
     _description = "Repair Order"
     _inherit = ["mrp.repair"]
 
+    distance_km = fields.Integer(string="Kilometers")
+    list_date = fields.Datetime(string="Lists date")
     operations = fields.One2many(
-        states={"draft": [("readonly", False)], "confirmed": [("readonly", False)]}
+        states={
+            "draft": [("readonly", False)],
+            "confirmed": [("readonly", False)],
+            "under_repair": [("readonly", False)],
+        }
     )
+
     fees_lines = fields.One2many(
-        states={"draft": [("readonly", False)], "confirmed": [("readonly", False)]}
+        states={
+            "draft": [("readonly", False)],
+            "confirmed": [("readonly", False)],
+            "under_repair": [("readonly", False)],
+        }
     )
 
     @api.multi
     def action_repair_cancel_draft(self):
+        """ if MO in under_repair or cancelled states, it can be set again to draft"""
+
         if self.filtered(lambda repair: repair.state not in ["cancel", "under_repair"]):
             raise UserError(_("Repair must be canceled in order to reset it to draft."))
         self.mapped("operations").write({"state": "draft"})
         return self.write({"state": "draft"})
+
+    def unlink(self):
+        if self.state in ("done", "2binvoiced"):
+            raise UserError(_("Cannot delete a finished Repair Order."))
+
+        return super(OxigenRepair, self).unlink()

--- a/oxigen_mrp_repair/views/mrp_repair_views.xml
+++ b/oxigen_mrp_repair/views/mrp_repair_views.xml
@@ -13,6 +13,30 @@
                     attrs="{'invisible':['|',('invoice_method','=','b4repair'), ('state', 'not in',('under_repair'))]}"
                 />
             </xpath>
+            <xpath expr="//field[@name='partner_id']" position="before">
+                <field name="distance_km" />
+            </xpath>
+            <xpath expr="//field[@name='guarantee_limit']" position="after">
+                 <field name="list_date" />
+            </xpath>
         </field>
     </record>
+
+     <record id="view_repair_order_tree" model="ir.ui.view">
+        <field name="name">mrp.repair.tree- oxigen_mrp_repair</field>
+        <field name="model">mrp.repair</field>
+        <field name="inherit_id" ref="mrp_repair.view_repair_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='guarantee_limit']" position="attributes">
+                 <attribute name="invisible">True</attribute>
+            </xpath>
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="lot_id" />
+                <field name="distance_km" />
+                <field name="list_date" />
+                <field name="guarantee_limit" />
+
+        </xpath>
+        </field>
+     </record>
 </odoo>


### PR DESCRIPTION
Added requested changes to mrp_repair:
- Product lines can be edited in the following states: Quotation, Confirmed, Under Repair
- Cannot delete finished MO (in Ready to Invoice or Repaired states)
- New fields: kilometros & Fecha de listas

