### PR TITLE
[11.0][FIX] oxigen_stock_barcodes: do not fail if res_model is undefinded.

### DIFF
--- a/oxigen_stock_barcodes/static/src/js/stock_barcodes.js
+++ b/oxigen_stock_barcodes/static/src/js/stock_barcodes.js
@@ -16,6 +16,7 @@ odoo.define("oxigen_stock_barcodes.ControlPanel", function(require) {
             Migration Note: likely not needed in versions >11.0
             */
             if (
+                !bc.action.action_descr.res_model ||
                 !bc.action.action_descr.res_model.includes("wiz.stock.barcodes.read.")
             ) {
                 return this._super(bc, index, length);


### PR DESCRIPTION
Before this, an error raised accesing the reconciliation widget.