### PR TITLE
[FIX] oxigen_stock_barcodes: tweak scan location logic

### DIFF
--- a/oxigen_stock_barcodes/models/stock_picking.py
+++ b/oxigen_stock_barcodes/models/stock_picking.py
@@ -10,7 +10,10 @@ class StockPicking(models.Model):
     def action_barcode_scan(self):
         self._prepare_stock_barcodes_sequence()
         action = super().action_barcode_scan()
-        if self.picking_type_code != "incoming":
+        if (
+            self.picking_type_code in ["internal", "outgoing"]
+            and self.location_id.usage != "transit"
+        ):
             # Ask to scan the source location
             ctx = action.get("context", {})
             ctx["default_message"] = _("Scan the Source Location")


### PR DESCRIPTION
* Do not require to scan transit locations.
* Do not skip the scan of destination locations of type 'view'.
* Change location not allowed to show regular info message
  instead of raising error:
![change-location-error](https://user-images.githubusercontent.com/23449160/149507397-a7d6764e-1235-4812-befb-f637e9993082.gif)

