### PR TITLE
[11.0][IMP] oxigen_mrp_repair: restrict creation of RO of lots being repaired

### DIFF
--- a/oxigen_mrp_repair/i18n/es.po
+++ b/oxigen_mrp_repair/i18n/es.po
@@ -47,3 +47,9 @@ msgstr "La reparación tiene que estar cancelada para poder volver a borrador"
 msgid "Set to Draft"
 msgstr "Volver a borrador"
 
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:59
+#, python-format
+msgid "Repair %s with lot %s of product %s must be finished before creating a new Repair order for the same lot."
+msgstr "La reparación %s con el lote %s del producto %s tiene que estar finalizada antes de abrir una nueva orden de reparación para el mismo lote"
+

--- a/oxigen_mrp_repair/i18n/oxigen_mrp_repair.pot
+++ b/oxigen_mrp_repair/i18n/oxigen_mrp_repair.pot
@@ -47,3 +47,9 @@ msgstr ""
 msgid "Set to Draft"
 msgstr ""
 
+#. module: oxigen_mrp_repair
+#: code:addons/oxigen_mrp_repair/models/mrp_repair.py:59
+#, python-format
+msgid "Repair %s with lot %s of product %s must be finished before creating a new Repair order for the same lot."
+msgstr ""
+

--- a/oxigen_mrp_repair/models/mrp_repair.py
+++ b/oxigen_mrp_repair/models/mrp_repair.py
@@ -37,7 +37,33 @@ class OxigenRepair(models.Model):
         return self.write({"state": "draft"})
 
     def unlink(self):
-        if self.state in ("done", "2binvoiced"):
-            raise UserError(_("Cannot delete a finished Repair Order."))
+        for rec in self:
+            if rec.state in ("done", "2binvoiced"):
+                raise UserError(_("Cannot delete a finished Repair Order."))
 
         return super(OxigenRepair, self).unlink()
+
+    @api.onchange("lot_id")
+    def onchange_lot_id(self):
+        if self.lot_id:
+            ro = self.env["mrp.repair"].search(
+                [
+                    ("product_id", "=", self.product_id.id),
+                    ("lot_id", "=", self.lot_id.id),
+                    ("state", "in", ("draft", "confirmed", "under_repair", "ready")),
+                ],
+                limit=1,
+            )
+            if ro:
+                raise UserError(
+                    _(
+                        "Repair %s with lot %s of product %s must be finished before "
+                        "creating a new Repair order for the same lot."
+                    )
+                    % (ro.name, self.lot_id.name, self.product_id.name)
+                )
+
+    def copy(self, default=None):
+        default = dict(default or {})
+        default.update({"lot_id": ""})
+        return super(OxigenRepair, self).copy(default)


### PR DESCRIPTION
If it already exists a RO of a certain combination of product and lot, a warning message appears.
Also, fixed a small bug in unlink function.