### PR TITLE
[14.0][IMP] oxigen_stock: inventory adjustment in view location

### DIFF
--- a/oxigen_stock/README.rst
+++ b/oxigen_stock/README.rst
@@ -4,6 +4,7 @@ Oxigen Stock
 
 * This module allows to set expiry dates and description when creating a lot
   from a picking.
+* Makes available to select a View Location in an Inventory Adjustment, then in the inventory lines all child locations will appear.
 
 Credits
 =======

--- a/oxigen_stock/models/__init__.py
+++ b/oxigen_stock/models/__init__.py
@@ -1,1 +1,1 @@
-from . import stock_location
+from . import stock_location, stock_inventory

--- a/oxigen_stock/models/stock_inventory.py
+++ b/oxigen_stock/models/stock_inventory.py
@@ -1,0 +1,10 @@
+# Copyright 2022 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class OxigenInventory(models.Model):
+    _inherit = "stock.inventory"
+
+    location_ids = fields.Many2many(domain="[('company_id', '=', company_id)]")


### PR DESCRIPTION
Makes available to select a View Location in an Inventory Adjustment, then in the inventory lines all child locations will appear.