### PR TITLE
[14.0][IMP] oxigen_account: bank journal flexibility

### DIFF
--- a/oxigen_account/README.rst
+++ b/oxigen_account/README.rst
@@ -2,7 +2,10 @@
 Oxigen Invoicing
 ==================
 
-* In a vendor bill, when Bill date field is changed it sets the same value in Accounting Date field.
+* In a vendor bill, when Bill date field is changed it sets the same value in
+  Accounting Date field.
+* Allow any account as outstanding receipt/payment account in journals. This allows
+  to configure SEPA payment order and return flow more easily.
 
 Credits
 =======
@@ -11,3 +14,4 @@ Contributors
 ------------
 
 * Maria de Luna <maria.de.luna@forgeflow.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/oxigen_account/models/__init__.py
+++ b/oxigen_account/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import account_journal

--- a/oxigen_account/models/account_journal.py
+++ b/oxigen_account/models/account_journal.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    # override domain in payment_debit_account_id and payment_credit_account_id:
+    payment_debit_account_id = fields.Many2one(
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+    )
+    payment_credit_account_id = fields.Many2one(
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+    )


### PR DESCRIPTION
Allow any account as outstanding recepeipt/payment account in
journals. This allow to configure SEPA payment order and
return flow more easily.