### PR TITLE
[14.0][IMP] oxigen_repair: user error if no customer defined

### DIFF
--- a/oxigen_repair/README.rst
+++ b/oxigen_repair/README.rst
@@ -7,6 +7,7 @@ Oxigen Repair
 * New fields: km, list_date
 * Cannot delete/cancel a finished Repair Order (state Done or To be Invoiced)
 * If there is an unfinished RO with a certain product and lot, a new one for the same lot can't be created until the previous one is finished.
+* Cannot add Parts/Operations in RO if no Customer is defined
 
 
 Credits

--- a/oxigen_repair/i18n/es.po
+++ b/oxigen_repair/i18n/es.po
@@ -78,3 +78,9 @@ msgstr "Volver a borrador"
 msgid "Repair %s with lot %s of product %s must be finished before creating a new Repair order for the same lot."
 msgstr "La reparación %s con el lote %s del producto %s tiene que estar finalizada antes de abrir una nueva orden de reparación para el mismo lote"
 
+#. module: oxigen_repair
+#: code:addons/oxigen_repair/models/repair_fee.py:0
+#: code:addons/oxigen_repair/models/repair_line.py:0
+#, python-format
+msgid "Please select a Customer"
+msgstr "Por favor seleccione un Cliente"

--- a/oxigen_repair/i18n/oxigen_repair.pot
+++ b/oxigen_repair/i18n/oxigen_repair.pot
@@ -78,3 +78,9 @@ msgstr ""
 msgid "Repair %s with lot %s of product %s must be finished before creating a new Repair order for the same lot."
 msgstr ""
 
+#. module: oxigen_repair
+#: code:addons/oxigen_repair/models/repair_fee.py:0
+#: code:addons/oxigen_repair/models/repair_line.py:0
+#, python-format
+msgid "Please select a Customer"
+msgstr ""

--- a/oxigen_repair/models/__init__.py
+++ b/oxigen_repair/models/__init__.py
@@ -1,1 +1,1 @@
-from . import repair
+from . import repair, repair_line, repair_fee

--- a/oxigen_repair/models/repair.py
+++ b/oxigen_repair/models/repair.py
@@ -1,4 +1,4 @@
-# Copyright 2021 ForgeFlow, S.L.
+# Copyright 2022 ForgeFlow, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models

--- a/oxigen_repair/models/repair_fee.py
+++ b/oxigen_repair/models/repair_fee.py
@@ -1,0 +1,14 @@
+# Copyright 2022 ForgeFlow, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class RepairFee(models.Model):
+    _inherit = "repair.fee"
+
+    @api.onchange("product_id")
+    def onchange_product_id(self):
+        if not self.repair_id.partner_id:
+            raise UserError(_("Please select a Customer"))

--- a/oxigen_repair/models/repair_line.py
+++ b/oxigen_repair/models/repair_line.py
@@ -1,0 +1,14 @@
+# Copyright 2022 ForgeFlow, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class RepairLine(models.Model):
+    _inherit = "repair.line"
+
+    @api.onchange("product_id")
+    def onchange_product_id(self):
+        if not self.repair_id.partner_id:
+            raise UserError(_("Please select a Customer"))


### PR DESCRIPTION
If the user tries to add Parts/Operations in a RO and the customer is not set a user error popup will appear.