### PR TITLE
[14.0][IMP] oxigen_stock: customized changes in operations report

### DIFF
--- a/oxigen_stock/README.rst
+++ b/oxigen_stock/README.rst
@@ -7,6 +7,7 @@ Oxigen Stock
 * Makes available to select a View Location in an Inventory Adjustment, then in the inventory lines all child locations will appear.
 * Sets default company as the current company in product creation
 * Defines Complete name of locations as in v11, taking the full path of parent locations
+* Adds customizations in internal pickings Operations Report
 
 Credits
 =======

--- a/oxigen_stock/i18n/es.po
+++ b/oxigen_stock/i18n/es.po
@@ -19,3 +19,8 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:oxigen_stock.oxigen_report_stockpicking_operations
 msgid "<strong>Reserved</strong>"
 msgstr "<strong>Reservado</strong>"
+
+#. module: oxigen_stock
+#: model_terms:ir.ui.view,arch_db:oxigen_stock.oxigen_report_stockpicking_operations
+msgid "<strong>Demand</strong>"
+msgstr "<strong>Demanda</strong>"

--- a/oxigen_stock/i18n/oxigen_stock.pot
+++ b/oxigen_stock/i18n/oxigen_stock.pot
@@ -19,3 +19,8 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:oxigen_stock.oxigen_report_stockpicking_operations
 msgid "<strong>Reserved</strong>"
 msgstr ""
+
+#. module: oxigen_stock
+#: model_terms:ir.ui.view,arch_db:oxigen_stock.oxigen_report_stockpicking_operations
+msgid "<strong>Demand</strong>"
+msgstr ""

--- a/oxigen_stock/report/report_stockpicking_operations.xml
+++ b/oxigen_stock/report/report_stockpicking_operations.xml
@@ -4,16 +4,156 @@
         id="oxigen_report_stockpicking_operations"
         inherit_id="stock.report_picking"
     >
-        <xpath expr="//table[1]/thead/tr/th[2]" position="after">
-            <th t-if="o.state != 'done'and o.picking_type_code == 'internal'">
-                <strong>Reserved</strong>
-            </th>
+<!--     New headers for internal transfer and state=assigned, also removed Product Barcode column-->
+        <xpath expr="//table[1]/thead/tr" position="attributes">
+            <attribute
+                name="t-if"
+            >o.state != 'assigned' or o.picking_type_code != 'internal'
+            </attribute>
         </xpath>
-        <xpath expr="//table[1]/tbody/t/t/tr/td[2]" position="after">
-             <td t-if="o.state != 'done' and o.picking_type_code == 'internal'">
+        <xpath expr="//table[1]/thead/tr" position="after">
+             <tr t-if="o.state == 'assigned'and o.picking_type_code == 'internal'">
+                <th name="th_product">
+                    <strong>Product</strong>
+                </th>
+                <th>
+                <strong>Demand</strong>
+                </th>
+                <th>
+                    <strong>Reserved</strong>
+                </th>
+                <th
+                    name="th_from"
+                    t-if="o.picking_type_id.code != 'incoming'"
+                    align="left"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <strong>From</strong>
+                </th>
+                <th
+                    name="th_to"
+                    t-if="o.picking_type_id.code != 'outgoing'"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <strong>To</strong>
+                </th>
+                <th
+                    name="th_serial_number"
+                    class="text-center"
+                    t-if="has_serial_number"
+                >
+                   <strong>Lot/Serial Number</strong>
+                </th>
+            </tr>
+        </xpath>
+<!--    If stock move has more than one line we add stock move info (demand and reserved) and then we will print stock move lines -->
+        <xpath expr="// table[1]/tbody/t/t" position="before">
+            <t
+                t-if="o.state == 'assigned' and o.picking_type_code == 'internal' and len(move.move_line_ids)==1"
+            >
+                <t t-set="style" t-value="'font-weight: bold'" />
+            </t>
+            <t
+                t-if="o.state == 'assigned' and o.picking_type_code == 'internal' and len(move.move_line_ids)!=1"
+            >
+                <t t-set="style" t-value="'font-weight: normal'" />
+            </t>
+            <tr
+                t-if="o.state == 'assigned' and o.picking_type_code == 'internal' and len(move.move_line_ids)!=1"
+                style="font-weight: bold"
+            >
+                <td>
+                    <span t-field="move.product_id.display_name" /><br />
+                    <span t-field="move.product_id.description_picking" />
+                </td>
+                <td>
+                    <span t-field="move.product_uom_qty" />
+                    <span t-field="move.product_uom" groups="uom.group_uom" />
+                </td>
+                <td>
                 <span t-field="move.reserved_availability" />
-                <span t-field="ml.product_uom_id" groups="uom.group_uom" />
-            </td>
+                <span t-field="move.product_uom" groups="uom.group_uom" />
+                </td>
+                <td
+                    t-if="o.picking_type_id.code != 'incoming'"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <span t-esc="move.location_id.display_name" />
+                </td>
+                <td
+                    t-if="o.picking_type_id.code != 'outgoing'"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <div>
+                        <span t-field="move.location_dest_id" />
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                </td>
+            </tr>
+        </xpath>
+<!--    Stock move lines info, some changes depending on whether there's only one stock move line-->
+        <xpath expr="//table[1]/tbody/t/t/tr" position="after">
+            <tr
+                t-if="o.state == 'assigned' and o.picking_type_code == 'internal'"
+                t-att-style="style"
+            >
+                <td t-if="len(move.move_line_ids)==1">
+                    <span t-field="ml.product_id.display_name" /><br />
+                    <span t-field="ml.product_id.description_picking" />
+                </td>
+                <td t-if="len(move.move_line_ids)!=1">
+                </td>
+                <td t-if="len(move.move_line_ids)==1">
+                    <span t-esc="move.product_uom_qty" />
+                    <span t-field="move.product_uom" groups="uom.group_uom" />
+                </td>
+                <td t-if="len(move.move_line_ids)!=1">
+                </td>
+                <td>
+                    <span t-if="o.state != 'done'" t-field="ml.product_uom_qty" />
+                    <span t-if="o.state == 'done'" t-field="ml.qty_done" />
+                    <span t-field="ml.product_uom_id" groups="uom.group_uom" />
+
+                </td>
+                <td
+                    t-if="o.picking_type_id.code != 'incoming'"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <span t-esc="ml.location_id.display_name" />
+                        <t t-if="ml.package_id">
+                            <span t-field="ml.package_id" />
+                        </t>
+                </td>
+                <td
+                    t-if="o.picking_type_id.code != 'outgoing'"
+                    groups="stock.group_stock_multi_locations"
+                >
+                    <div>
+                        <span t-field="ml.location_dest_id" />
+                        <t t-if="ml.result_package_id">
+                            <span t-field="ml.result_package_id" />
+                        </t>
+                    </div>
+                </td>
+                <td class=" text-center h6" t-if="has_serial_number">
+                    <img
+                        t-if="has_serial_number and (ml.lot_id or ml.lot_name)"
+                        t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;humanreadable=1' % ('Code128', ml.lot_id.name or ml.lot_name, 400, 100)"
+                        style="width:100%;height:35px;"
+                        alt="Barcode"
+                    />
+                </td>
+            </tr>
+        </xpath>
+<!--    We hide old stock move line info-->
+        <xpath expr="//table[1]/tbody/t/t/tr[1]" position="attributes">
+           <attribute
+                name="t-if"
+            >o.state != 'assigned' or o.picking_type_code != 'internal'
+           </attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Now it looks like this (only for internal pickings and state Assigned):

![image](https://user-images.githubusercontent.com/85128566/167092251-cf807218-053f-46fb-9922-ff5855e9d9da.png)
