### PR TITLE
[14.0][FIX] oxigen_stock: remove onchange function removed from odoo CE

### DIFF
--- a/oxigen_stock/models/stock_picking.py
+++ b/oxigen_stock/models/stock_picking.py
@@ -7,13 +7,6 @@ from odoo import api, models
 class Picking(models.Model):
     _inherit = "stock.picking"
 
-    @api.onchange("location_id", "location_dest_id", "picking_type_id")
-    def onchange_locations(self):
-        res = super().onchange_locations()
-        if isinstance(res, dict) and "warning" in res:
-            # Override intercompany warning.
-            return {}
-
     @api.depends("state", "move_lines", "move_ids_without_package")
     def _compute_show_mark_as_todo(self):
         super()._compute_show_mark_as_todo()


### PR DESCRIPTION
`onchange_locations ` removed in https://github.com/odoo/odoo/commit/a9dc406b52a3702f6901f686503e8d841f81724e.

