### PR TITLE
[14.0][FIX] oxigen_stock: fix deliveryslip

### DIFF
--- a/oxigen_stock/report/report_deliveryslip.xml
+++ b/oxigen_stock/report/report_deliveryslip.xml
@@ -9,7 +9,7 @@
             expr="//table[@name='stock_move_table']//tr[@t-as='move']//span[@t-field='move.description_picking']"
             position="attributes"
         >
-            <attribute name="style">visibility: hidden</attribute>
+            <attribute name="t-if">False</attribute>
         </xpath>
     </template>
 
@@ -21,10 +21,13 @@
             expr='//t[@t-value="move_line.move_id.description_picking"]'
             position="attributes"
         >
-            <attribute name="style">visibility: hidden</attribute>
+            <attribute name="t-if">False</attribute>
         </xpath>
-        <xpath expr="//span[@t-esc='description']" position="attributes">
-            <attribute name="style">visibility: hidden</attribute>
+        <xpath
+            expr='//p[normalize-space(@t-if)="description !=&apos;&apos; and description != move_line.product_id.name"]'
+            position="attributes"
+        >
+            <attribute name="t-if">False</attribute>
         </xpath>
     </template>
 
@@ -36,7 +39,7 @@
             expr='//tr[@t-as="line"]//p[@t-if="aggregated_lines[line][&apos;description&apos;]"]'
             position="attributes"
         >
-            <attribute name="style">visibility: hidden</attribute>
+            <attribute name="t-if">False</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
`visibility: hidden` hides the field but maintains the space that it was using in the report. Solved with `t-if=False.`

Also, added xpath to a t-if with spaces using `normalize-space.`