### PR TITLE
[14.0][IMP] oxigen_repair: avoid inconsistency in compute_sudo

### DIFF
--- a/oxigen_repair/models/product_product.py
+++ b/oxigen_repair/models/product_product.py
@@ -7,6 +7,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     repair_count = fields.Float(
+        compute_sudo=True,
         compute="_compute_repair",
         string="Repairs",
         help="Number of Repair Orders where the product appears as a Part",

--- a/oxigen_repair/models/product_template.py
+++ b/oxigen_repair/models/product_template.py
@@ -5,6 +5,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     repair_count = fields.Float(
+        compute_sudo=True,
         compute="_compute_repair",
         string="Repairs",
         help="Number of Repair Orders where the product appears as a Part",


### PR DESCRIPTION
compute_sudo is True by default if the field is store, but False if the field is not stored. Thus, as this compute is called in both a stored and a non stored field, we set compute_sudo as True for the non stored.
![Selection_442](https://user-images.githubusercontent.com/25005517/172824000-0b76f04f-405e-4b55-99d0-4380841de1a1.png)

