### PR TITLE
[14.0][UPD] oxigen_stock: remove previous IMP because it's merged in odoo

### DIFF
--- a/oxigen_stock/models/stock_picking.py
+++ b/oxigen_stock/models/stock_picking.py
@@ -15,7 +15,3 @@ class Picking(models.Model):
             and r.state == "draft"
         ):
             rec.show_mark_as_todo = True
-
-    def _send_confirmation_email(self):
-        # https://github.com/odoo/odoo/pull/92870
-        return super(Picking, self.sudo())._send_confirmation_email()


### PR DESCRIPTION
revert https://github.com/oxigensalud/odoo-addons/pull/78 because it's now merged in odoo (https://github.com/odoo/odoo/pull/93447)