### PR TITLE
[14.0][IMP] oxigen_stock: see detailed operations in Picking Operations report

### DIFF
--- a/oxigen_stock/report/report_stockpicking_operations.xml
+++ b/oxigen_stock/report/report_stockpicking_operations.xml
@@ -155,5 +155,29 @@
             >o.state != 'assigned' or o.picking_type_code != 'internal'
            </attribute>
         </xpath>
+<!--    We want that when state=ready in incoming ops if there are defined detailed operations, only these are shown for that move-->
+        <xpath expr="//table[1]/tbody/t/t" position="attributes">
+            <attribute
+                name="t-if"
+            >o.picking_type_code != 'incoming' or (o.picking_type_code == 'incoming' and ((has_detailed_op and ml.qty_done) or not has_detailed_op))
+            </attribute>
+        </xpath>
+        <xpath expr="//table[1]/tbody/t/t" position="after">
+            <t
+                t-set="has_detailed_op"
+                t-value="any(move_line.qty_done for move_line in move.move_line_ids)"
+            />
+        </xpath>
+        <xpath expr="//table[1]/tbody/t/t/tr/td[2]" position="attributes">
+            <attribute name="t-if">o.picking_type_code != 'incoming'
+            </attribute>
+        </xpath>
+        <xpath expr="// table[1]/tbody/t/t/tr/td[2]" position="after">
+            <td t-if="o.picking_type_code == 'incoming'">
+                <span t-if="has_detailed_op and ml.qty_done" t-field="ml.qty_done" />
+                <span t-else="" t-field="ml.product_uom_qty" />
+                <span t-field="ml.product_uom_id" groups="uom.group_uom" />
+            </td>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
To avoid printing this in Picking Operations report when state=ready in incoming pickings :
![image](https://user-images.githubusercontent.com/85128566/197813207-594ca0e4-1b68-48ea-8f4b-6285d006a124.png)

and there are Detailed Operations:
![image](https://user-images.githubusercontent.com/85128566/197813297-9d760983-ecc9-4b9d-b9dc-35fcfaeab111.png)
