### PR TITLE
[FIX] oxigen_account: Only review it when we have a posted document

### DIFF
--- a/oxigen_account/tests/test_supplier_invoice.py
+++ b/oxigen_account/tests/test_supplier_invoice.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
@@ -43,14 +45,17 @@ class TestSupplierInvoice(AccountTestInvoicingCommon):
 
     def test_check_unique_supplier_invoice_number_insensitive(self):
         # A new invoice instance with an existing supplier_invoice_number
+        move = self.account_move.create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "in_invoice",
+                "invoice_date": fields.Date.today() + timedelta(days=-1),
+                "ref": "ABC123",
+                "invoice_line_ids": [(0, 0, {})],
+            }
+        )
         with self.assertRaises(ValidationError):
-            self.account_move.create(
-                {
-                    "partner_id": self.partner.id,
-                    "move_type": "in_invoice",
-                    "ref": "ABC123",
-                }
-            )
+            move.action_post()
         # A new invoice instance with a new supplier_invoice_number
         self.account_move.create(
             {


### PR DESCRIPTION
@eantones 
Este cambio es necesario ya que en ocasiones creamos facturas con la misma referencia (Como en contratos) y quedamos a la espera de introducir el dato correcto cuando el proveedor nos envíe la factura correcta. Si nos esperamos demasiado nos encontramos que se puede crear la siguiente factura con la misma referencia, el del contrato, y con el código anterior esto fallaba.
La otra opción es modificar el texto de la referencia en facturas que vienen de contrato, aunque este cambio me sigue pareciendo necesario.