### PR TITLE
[14.0][FIX] connector_oxigesti_spms: fix date offset on SPMS sale order line dates

### DIFF
--- a/connector_oxigesti_spms/models/backend/backend.py
+++ b/connector_oxigesti_spms/models/backend/backend.py
@@ -73,7 +73,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -105,7 +105,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -137,7 +137,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -169,7 +169,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -201,7 +201,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -233,7 +233,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 
@@ -265,7 +265,7 @@ class OxigestiSPMSBackend(models.Model):
             domain = []
             if last_since_date:
                 domain.append(
-                    ("Fecha_Modifica", ">=", backend.tz_to_local(last_since_date))
+                    ("Fecha_Modifica", ">=", backend.utc_to_server_tz(last_since_date))
                 )
             binding.import_data(backend, domain=domain)
 

--- a/connector_oxigesti_spms/models/sale_order/export_mapper.py
+++ b/connector_oxigesti_spms/models/sale_order/export_mapper.py
@@ -21,10 +21,6 @@ class OxigestiSpmsSaleOrderExportMapper(Component):
     @mapping
     def Odoo_Fecha_Generado_Albaran(self, record):
         if record.state in ["sale", "done"]:
-            return {
-                "Odoo_Fecha_Generado_Albaran": self.backend_record.tz_to_local(
-                    record["date_order"]
-                )
-            }
+            return {"Odoo_Fecha_Generado_Albaran": record["date_order"]}
         else:
             return

--- a/connector_oxigesti_spms/models/sale_order/import_mapper.py
+++ b/connector_oxigesti_spms/models/sale_order/import_mapper.py
@@ -37,7 +37,7 @@ class OxigestiSpmsSaleOrderImporterMapper(Component):
 
     @mapping
     def date_order(self, record):
-        return {"date_order": self.backend_record.tz_to_utc(record["DataFactura"])}
+        return {"date_order": record["DataFactura"]}
 
     children = [
         ("lines", "oxigesti_spms_order_lines_ids", "oxigesti.spms.sale.order.line")

--- a/connector_oxigesti_spms/models/sale_order_line/import_mapper.py
+++ b/connector_oxigesti_spms/models/sale_order_line/import_mapper.py
@@ -1,4 +1,5 @@
 # Copyright 2025 NuoBiT - Deniz Gallo <dgallo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import changed_by, mapping, only_create
@@ -29,12 +30,18 @@ class OxigestiSpmsSaleOrderLineImporterMapper(Component):
     @only_create
     @mapping
     def spms_start_date(self, record):
-        return {"spms_start_date": record["DataInicio"]}
+        value = record["DataInicio"]
+        if value:
+            value = self.backend_record.tz_to_local(value).date()
+        return {"spms_start_date": value}
 
     @only_create
     @mapping
     def spms_end_date(self, record):
-        return {"spms_end_date": record["DataFim"]}
+        value = record["DataFim"]
+        if value:
+            value = self.backend_record.tz_to_local(value).date()
+        return {"spms_end_date": value}
 
     @changed_by("product_id")
     @mapping

--- a/connector_oxigesti_spms/models/sale_order_line/import_mapper.py
+++ b/connector_oxigesti_spms/models/sale_order_line/import_mapper.py
@@ -32,7 +32,7 @@ class OxigestiSpmsSaleOrderLineImporterMapper(Component):
     def spms_start_date(self, record):
         value = record["DataInicio"]
         if value:
-            value = self.backend_record.tz_to_local(value).date()
+            value = self.backend_record.utc_to_local(value).date()
         return {"spms_start_date": value}
 
     @only_create
@@ -40,7 +40,7 @@ class OxigestiSpmsSaleOrderLineImporterMapper(Component):
     def spms_end_date(self, record):
         value = record["DataFim"]
         if value:
-            value = self.backend_record.tz_to_local(value).date()
+            value = self.backend_record.utc_to_local(value).date()
         return {"spms_end_date": value}
 
     @changed_by("product_id")

--- a/connector_oxigesti_spms/views/backend_views.xml
+++ b/connector_oxigesti_spms/views/backend_views.xml
@@ -47,9 +47,14 @@
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"
                                 widget="many2many_tags"
                             />
+                        </group>
+                        <group>
                             <field
                                 name="tz"
-                                colspan="4"
+                                attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            />
+                            <field
+                                name="server_tz"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"
                             />
                         </group>

--- a/connector_oxigesti_spms/views/backend_views.xml
+++ b/connector_oxigesti_spms/views/backend_views.xml
@@ -32,15 +32,11 @@
                         />
                     </h1>
                     <group>
-                        <group col="4">
+                        <group>
                             <field
                                 name="company_id"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}"
                                 domain="[('id', 'in', allowed_company_ids)]"
-                            />
-                            <field
-                                name="user_id"
-                                attrs="{'readonly': [('state', '!=', 'draft')]}"
                             />
                             <field
                                 name="lang_ids"
@@ -48,15 +44,23 @@
                                 widget="many2many_tags"
                             />
                         </group>
-                        <group>
-                            <field
-                                name="tz"
-                                attrs="{'readonly': [('state', '!=', 'draft')]}"
-                            />
-                            <field
-                                name="server_tz"
-                                attrs="{'readonly': [('state', '!=', 'draft')]}"
-                            />
+                        <group col="1">
+                            <group>
+                                <field
+                                    name="user_id"
+                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                />
+                            </group>
+                            <group>
+                                <field
+                                    name="tz"
+                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                />
+                                <field
+                                    name="server_tz"
+                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                />
+                            </group>
                         </group>
                         <group>
                             <field


### PR DESCRIPTION
## Summary
- Fix -1 day offset on `spms_start_date` and `spms_end_date` fields in SPMS sale order lines
- The SQL adapter automatically converts MSSQL datetimes to UTC, but these `Date` fields need the local calendar date, not the UTC date
- Convert UTC back to local timezone before extracting `.date()` to preserve the correct calendar date

## Test plan
- [ ] Import a sale order from SPMS with known `DataInicio`/`DataFim` values
- [ ] Verify `spms_start_date` and `spms_end_date` match the MSSQL source dates
- [ ] Verify existing sale orders with NULL dates still import correctly