### PR TITLE
[14.0][FIX] connector_oxigesti_spms: only block duplicate invoice on SPMS-bound SOs

### DIFF
--- a/connector_oxigesti_spms/models/account_move/listener.py
+++ b/connector_oxigesti_spms/models/account_move/listener.py
@@ -1,4 +1,5 @@
 # Copyright 2025 NuoBiT - Deniz Gallo <dgallo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import _
@@ -16,27 +17,27 @@ class OXigestiSPMSAccountInvoiceListener(Component):
     def on_validate_out_invoice(self, record):
         record.ensure_one()
         for order in record.invoice_line_ids.sale_line_ids.order_id:
-            invoices = order.invoice_ids.filtered(
-                lambda inv: inv != record and inv.state == "posted"
-            )
-            if invoices:
-                raise UserError(
-                    _(
-                        "This invoice cannot be validated because the "
-                        "associated sales order already has related invoice lines. "
-                        "Please review the sales order and ensure it does "
-                        "not have any existing invoices linked before proceeding."
-                    )
+            bindings = order.oxigesti_spms_bind_ids
+            if bindings:
+                other_invoices = order.invoice_ids.filtered(
+                    lambda inv: inv != record
+                    and inv.state == "posted"
+                    and inv.move_type == "out_invoice"
                 )
-            binding = order.oxigesti_spms_bind_ids
-            if binding:
-                binding.ensure_one()
-                binding.export_invoice_data(record)
+                if other_invoices:
+                    raise UserError(
+                        _(
+                            "This invoice cannot be validated because the "
+                            "associated sales order already has related invoice lines. "
+                            "Please review the sales order and ensure it does "
+                            "not have any existing invoices linked before proceeding."
+                        )
+                    )
+                for binding in bindings:
+                    binding.export_invoice_data(record)
 
     def on_cancel_out_invoice(self, record):
         record.ensure_one()
         for order in record.invoice_line_ids.mapped("sale_line_ids.order_id"):
-            binding = order.oxigesti_spms_bind_ids
-            if binding:
-                binding.ensure_one()
+            for binding in order.oxigesti_spms_bind_ids:
                 binding.export_invoice_data(record, clear=True)


### PR DESCRIPTION
## Problem

On a sale order that is **not bound to SPMS**, trying to post a second draft invoice (typical split-invoice flow: bill some lines now, the rest later) raises:

> *This invoice cannot be validated because the associated sales order already has related invoice lines. Please review the sales order and ensure it does not have any existing invoices linked before proceeding.*

Reproduced on production SO `SO/2026/06587` (customer `BRUGUES ASISTENCIAL SAU`, industrial/non-SPMS). The SO has `oxigesti_spms_bind_ids = []`, so no SPMS data-integrity concern exists, yet the listener still blocks posting.

## Root cause

`connector_oxigesti_spms/models/account_move/listener.py` — `on_validate_out_invoice`:

```python
for order in record.invoice_line_ids.sale_line_ids.order_id:
    invoices = order.invoice_ids.filtered(
        lambda inv: inv != record and inv.state == "posted"
    )
    if invoices:
        raise UserError(...)
    binding = order.oxigesti_spms_bind_ids
    if binding:
        binding.ensure_one()
        binding.export_invoice_data(record)
```

Two problems:

1. The duplicate-invoice check fires for **every** SO referenced by the invoice, regardless of whether the SO has an SPMS binding. The constraint only makes sense for SPMS-bound SOs (the single `Odoo_Numero_Factura` slot in the remote SPMS record can hold exactly one invoice number). Non-SPMS SOs have no such slot, so there is no data-integrity reason to block.
2. The prior-invoice filter doesn't exclude `out_refund`. Combined with the edge case "original cancelled, refund still posted" (where `on_cancel_out_invoice` already cleared the remote slot), a lingering posted refund would incorrectly count as "another posted invoice" and block a legitimate new invoice.
3. `binding.ensure_one()` assumes a single SPMS backend globally. The schema (`unique(backend_id, odoo_id)` on `oxigesti.spms.binding`) already supports one binding per backend, so the code should iterate.

## Fix

- Gate the guard by presence of a binding on the SO: `if not bindings: continue`. Non-SPMS SOs skip the check and the export.
- Filter prior invoices by `move_type == 'out_invoice'` (defensive — refunds don't fire the listener anyway after commit 37457a3, but the filter prevents false positives in the cancel+refund edge case).
- Replace `binding.ensure_one()` with `for binding in bindings:`; applied symmetrically to `on_cancel_out_invoice`.

## Related

- Complements #165 / commit `37457a3` (`skip SPMS events for non-sale invoices`), which fixed the same family of false positives at the *dispatch* level. This PR fixes the residual false positives at the *filter* level inside the listener.

## Behavior table (after this PR)

| Scenario | Before | After |
|---|---|---|
| Non-SPMS SO, multiple invoices | BLOCKED (bug) | allowed |
| SPMS SO, nothing before, new invoice | allowed | allowed |
| SPMS SO, posted invoice alive, new invoice | BLOCKED | BLOCKED |
| SPMS SO, posted original + posted refund, new invoice | BLOCKED | BLOCKED (original still counts) |
| SPMS SO, original cancelled + refund posted, new invoice | BLOCKED | allowed (slot cleared by `on_cancel`) |

## Test plan

- [ ] Install/update the module on a dev DB clone of production.
- [ ] Reproduce SO/2026/06587 scenario (non-SPMS SO with posted + refunded invoice, create new draft, delete a line, post) → must succeed.
- [ ] Verify SPMS-bound SO still blocks a second concurrent posted invoice.
- [ ] Verify refund posting (both on SPMS and non-SPMS SOs) remains unaffected.
- [ ] Verify `on_cancel_out_invoice` correctly clears remote slots for each binding.