### PR TITLE
[14.0][FIX] oxigen_l10n_es: deduplicate p_iva5_nd against l10n_es

### DIFF
--- a/oxigen_l10n_es/__manifest__.py
+++ b/oxigen_l10n_es/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Oxigen Localization",
     "summary": "Customizations to PGCE for Oxigen",
-    "version": "14.0.1.0.8",
+    "version": "14.0.1.0.9",
     "author": "ForgeFlow",
     "website": "https://github.com/oxigensalud/odoo-addons",
     "category": "Accounting/Localizations/Account Charts",

--- a/oxigen_l10n_es/data/aeat_sii_map_data.xml
+++ b/oxigen_l10n_es/data/aeat_sii_map_data.xml
@@ -14,7 +14,7 @@
                 ref('oxigen_l10n_es.account_tax_template_p_iva4nd_ic_bi'),
                 ref('oxigen_l10n_es.account_tax_template_p_iva4nd_ic_bc'),
                 ref('oxigen_l10n_es.account_tax_template_p_iva4nd_sp_in'),
-                ref('oxigen_l10n_es.account_tax_template_p_iva5_nd'),
+                ref('l10n_es.account_tax_template_p_iva5_nd'),
                 ref('l10n_es.account_tax_template_p_iva10_nd'),
                 ref('oxigen_l10n_es.account_tax_template_p_iva10_nd_bc'),
                 ref('oxigen_l10n_es.account_tax_template_p_iva10_nd_bi'),

--- a/oxigen_l10n_es/data/legacy_account_tax_data.xml
+++ b/oxigen_l10n_es/data/legacy_account_tax_data.xml
@@ -97,43 +97,14 @@
     </record>
 
     <!--     5% -->
-    <record id="account_tax_template_p_iva5_nd" model="account.tax.template">
-        <field name="type_tax_use">purchase</field>
+    <!-- The 5% non-deductible tax template used to be declared here as an own
+         template because l10n_es did not ship one yet. l10n_es now provides
+         account_tax_template_p_iva5_nd, so we only override its name, the same
+         way the other non-deductible rates below do. The migration script of
+         14.0.1.0.9 rebadges/removes the taxes instantiated from the old own
+         template. -->
+    <record id="l10n_es.account_tax_template_p_iva5_nd" model="account.tax.template">
         <field name="name">IVA Soportado no deducible 5% (servicios corrientes)</field>
-        <field name="chart_template_id" ref="l10n_es.account_chart_template_common" />
-        <field name="amount" eval="5" />
-        <field name="amount_type">percent</field>
-        <field name="analytic" eval="True" />
-        <field name="tax_group_id" ref="l10n_es.tax_group_iva_nd" />
-        <field
-            name="invoice_repartition_line_ids"
-            eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-
-        ]"
-        />
-        <field
-            name="refund_repartition_line_ids"
-            eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"
-        />
     </record>
 
     <!--     10% -->

--- a/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
+++ b/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
@@ -1,0 +1,149 @@
+# Copyright 2026 NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+TEMPLATE_KEY = "account_tax_template_p_iva5_nd"
+
+
+def _same_shape(tax, template):
+    """Is the tax functionally identical to the official template?"""
+
+    def sig(lines):
+        return [
+            (line.repartition_type, line.factor_percent, bool(line.account_id))
+            for line in lines.sorted("sequence")
+        ]
+
+    return (
+        tax.amount_type == template.amount_type
+        and tax.amount == template.amount
+        and tax.type_tax_use == template.type_tax_use
+        and tax.price_include == template.price_include
+        and sig(tax.invoice_repartition_line_ids)
+        == sig(template.invoice_repartition_line_ids)
+        and sig(tax.refund_repartition_line_ids)
+        == sig(template.refund_repartition_line_ids)
+    )
+
+
+def _ref_count(env, tax_id):
+    """References that make a duplicated tax unsafe to delete.
+
+    Discovered dynamically from the registry, no table of any module is
+    named. Of every way Odoo can link a record, the two that matter for a
+    safe unlink are counted:
+
+    - stored many2many: the one channel where a delete loses data silently
+      (PostgreSQL cascades the relation rows without a word);
+    - stored many2one: fields declaring ondelete set-null/cascade would
+      also mutate silently — and one2many needs no leg of its own, its
+      storage IS the inverse many2one. (restrict ones would abort the
+      update loudly by themselves.)
+
+    Deliberately NOT counted: soft references (fields.Reference,
+    many2one_reference, res_model/res_id pairs, ir.property values) —
+    standard Odoo deletion does not guard them either and their orphans
+    are inert; and textual/serialized ids (filter domains, action code),
+    which are not structural. Abstract/transient models and SQL views are
+    skipped.
+    """
+    cr = env.cr
+    total = 0
+    seen_m2m = set()
+    for model_name in env.registry:
+        model = env[model_name]
+        if model._abstract or model._transient or not model._auto:
+            continue
+        for field in model._fields.values():
+            if not field.store or field.comodel_name != "account.tax":
+                continue
+            if field.type == "many2one":
+                table, column = model._table, field.name
+            elif field.type == "many2many":
+                if (field.relation, field.column2) in seen_m2m:
+                    continue
+                seen_m2m.add((field.relation, field.column2))
+                table, column = field.relation, field.column2
+            else:
+                continue
+            cr.execute(
+                'SELECT count(*) FROM "{}" WHERE "{}" = %s'.format(table, column),
+                (tax_id,),
+            )
+            total += cr.fetchone()[0]
+    return total
+
+
+def migrate(cr, version):
+    """Deduplicate the 5% non-deductible tax against l10n_es.
+
+    The own template (oxigen_l10n_es.account_tax_template_p_iva5_nd) predates
+    the official one and is dropped by this version. Per company holding a tax
+    born from the own template:
+
+    - official tax MISSING: the existing record is the real historical tax of
+      the company, so it simply BECOMES the official one (xml-id module
+      switch; nothing else is touched);
+    - official tax PRESENT (both templates were instantiated): the duplicate
+      must be unused, it is deleted and the official stays.
+
+    The own template row itself is garbage-collected by this same update (its
+    xml-id is noupdate=False and the record left the data files); its SII map
+    membership is replaced by the official ref in data/aeat_sii_map_data.xml.
+    """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    template = env.ref("l10n_es." + TEMPLATE_KEY)
+    imd_model = env["ir.model.data"]
+    clone_imds = imd_model.search(
+        [("module", "=", "oxigen_l10n_es"), ("model", "=", "account.tax")]
+    ).filtered(lambda d: d.name.endswith("_" + TEMPLATE_KEY))
+    for imd in clone_imds:
+        tax = env["account.tax"].browse(imd.res_id).exists()
+        if not tax:
+            imd.unlink()
+            continue
+        official_imd = imd_model.search(
+            [
+                ("module", "=", "l10n_es"),
+                ("model", "=", "account.tax"),
+                ("name", "=", imd.name),
+            ]
+        )
+        if official_imd:
+            refs = _ref_count(env, tax.id)
+            if refs:
+                raise RuntimeError(
+                    "p_iva5_nd dedup: tax %s (company %s) duplicates official"
+                    " %s but is referenced %s time(s); refusing to delete"
+                    % (tax.id, tax.company_id.id, official_imd.res_id, refs)
+                )
+            _logger.info(
+                "p_iva5_nd dedup: deleting unused duplicated tax %s"
+                " (company %s); official %s stays",
+                tax.id,
+                tax.company_id.id,
+                official_imd.res_id,
+            )
+            tax.unlink()
+            if imd.exists():
+                imd.unlink()
+        else:
+            if not _same_shape(tax, template):
+                raise RuntimeError(
+                    "p_iva5_nd dedup: tax %s (company %s) diverges from the"
+                    " official definition; refusing to rebadge"
+                    % (tax.id, tax.company_id.id)
+                )
+            _logger.info(
+                "p_iva5_nd dedup: rebadging tax %s (company %s) as l10n_es.%s",
+                tax.id,
+                tax.company_id.id,
+                imd.name,
+            )
+            imd.write({"module": "l10n_es"})

--- a/oxigen_l10n_es_account_asset_tax_consistency/__manifest__.py
+++ b/oxigen_l10n_es_account_asset_tax_consistency/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Oxigen - L10n ES - Account Tax Consistency",
     "summary": "This module adds in taxes of l10n_es data account asset tax selection field",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Accounting",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/oxigensalud/odoo-addons",

--- a/oxigen_l10n_es_account_asset_tax_consistency/data/l10n_es_account_asset_tax_consistency_data.xml
+++ b/oxigen_l10n_es_account_asset_tax_consistency/data/l10n_es_account_asset_tax_consistency_data.xml
@@ -115,10 +115,9 @@
         <field name="apply_to_asset">always</field>
     </record>
     <!--    	IVA Soportado no deducible 5% (servicios corrientes)-->
-    <record
-        id="oxigen_l10n_es.account_tax_template_p_iva5_nd"
-        model="account.tax.template"
-    >
+    <!-- oxigen_l10n_es no longer clones this template: the rule targets the
+         official l10n_es one. -->
+    <record id="l10n_es.account_tax_template_p_iva5_nd" model="account.tax.template">
         <field name="apply_to_asset">never</field>
     </record>
 </odoo>


### PR DESCRIPTION
The 5% non-deductible VAT template was added here in 2022 as an own template (`account_tax_template_p_iva5_nd`) because `l10n_es` did not ship one yet. l10n_es has provided the official template for a while, so keeping the own copy instantiates duplicated taxes (company 13 ended up with two identical active taxes) and forces custom SII/asset wiring.

This aligns the 5% with how the module already treats the other non-deductible rates (0/4/10/21: name-only override on the official template):

- **oxigen_l10n_es**: the own template becomes a name override of `l10n_es.account_tax_template_p_iva5_nd`; the SII SFRND map line points to the official template; migration 14.0.1.0.9 rebadges the taxes born from the own template to the official xml-id where the official tax is missing (companies 3/4/5/9 — history untouched: 351 move lines and 11 archived contract lines keep their tax record) and deletes the unused duplicate where the official already exists (company 13, 0 references, guarded).
- **oxigen_l10n_es_account_asset_tax_consistency**: the asset rule targets the official template.

Impact checked on the production database: the template is not referenced by any 303/322/390/VAT-book map (non-deductible VAT maps to no box) and its taxes never entered a generated AEAT report; the only live wiring was the SII SFRND line and the asset rule, both transferred here. The own template row is garbage-collected on update (noupdate=False, record left the data files).
