### PR TITLE
[14.0][FIX] oxigen_l10n_es: exclude own repartition lines from the dedup reference count

### DIFF
--- a/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
+++ b/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
@@ -13,9 +13,12 @@ def _same_shape(tax, template):
     """Is the tax functionally identical to the official template?"""
 
     def sig(lines):
+        # Template repartition lines carry no sequence field (only the
+        # real ones do); each side sorts by the ordering key it has.
+        key = "sequence" if "sequence" in lines._fields else "id"
         return [
             (line.repartition_type, line.factor_percent, bool(line.account_id))
-            for line in lines.sorted("sequence")
+            for line in lines.sorted(key)
         ]
 
     return (

--- a/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
+++ b/oxigen_l10n_es/migrations/14.0.1.0.9/post-migration.py
@@ -30,6 +30,17 @@ def _same_shape(tax, template):
     )
 
 
+def _component_columns(env):
+    """(table, column) pairs that store a tax's own one2many children."""
+    cols = set()
+    for field in env["account.tax"]._fields.values():
+        if field.type == "one2many" and field.inverse_name:
+            comodel = env[field.comodel_name]
+            if comodel._auto and not comodel._abstract and not comodel._transient:
+                cols.add((comodel._table, field.inverse_name))
+    return cols
+
+
 def _ref_count(env, tax_id):
     """References that make a duplicated tax unsafe to delete.
 
@@ -44,6 +55,12 @@ def _ref_count(env, tax_id):
       storage IS the inverse many2one. (restrict ones would abort the
       update loudly by themselves.)
 
+    The tax's own one2many children (its repartition lines) arrive through
+    that same inverse-many2one channel but are components, not references —
+    they die with the record — so their columns are excluded; counting them
+    made this guard refuse every tax (a real tax always carries repartition
+    lines) and the delete branch was unreachable.
+
     Deliberately NOT counted: soft references (fields.Reference,
     many2one_reference, res_model/res_id pairs, ir.property values) —
     standard Odoo deletion does not guard them either and their orphans
@@ -52,6 +69,7 @@ def _ref_count(env, tax_id):
     skipped.
     """
     cr = env.cr
+    excluded = _component_columns(env)
     total = 0
     seen_m2m = set()
     for model_name in env.registry:
@@ -62,6 +80,8 @@ def _ref_count(env, tax_id):
             if not field.store or field.comodel_name != "account.tax":
                 continue
             if field.type == "many2one":
+                if (model._table, field.name) in excluded:
+                    continue
                 table, column = model._table, field.name
             elif field.type == "many2many":
                 if (field.relation, field.column2) in seen_m2m:


### PR DESCRIPTION
Fixes a latent crash in the p_iva5_nd dedup migration (14.0.1.0.9, merged in #216) surfaced by the first prod-like database rehearsal.

**Symptom.** `-u all` on a production snapshot aborts with `RuntimeError: p_iva5_nd dedup: tax ... (company 13) duplicates official ... but is referenced 4 time(s); refusing to delete`.

**Root cause.** The safety guard counts every stored many2one/many2many pointing at the tax before deleting an unused duplicate. A tax's own repartition lines reach it through that same inverse-many2one channel (`account_tax_repartition_line.invoice_tax_id`/`refund_tax_id`), so every real tax always counts at least its four component rows: the delete branch was unreachable. Company 13 is the only one holding both the official tax and the clone, so it is the only place the branch runs.

**Fix.** Exclude the tax's own one2many component columns from the count (components die with the record — the repartition FK is `ON DELETE CASCADE`), mirroring the component exclusion the 14.0.1.2.0 adoption migration already applies.

**Why CI never caught it.** Fresh installs have no clone taxes (the own template left the data files in #216), so the migration no-ops there; only a real database exercises the duplicate path.

## Test plan
- [x] pre-commit passes locally
- [ ] CI green
- [ ] Prod-snapshot rehearsal: `-u all` completes; company 13 duplicate deleted (its 4 repartition rows with it), companies 3/4/5/9 rebadged
