### PR TITLE
[18.0][IMP] update copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,7 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.35
+_commit: v1.44
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
 enable_checklog_odoo: true
 generate_requirements_txt: true
@@ -17,6 +16,7 @@ odoo_test_flavor: Both
 odoo_version: 18.0
 org_name: Oxigen Salud SA
 org_slug: oxigensalud
+postgres_image: ''
 rebel_module_groups: []
 repo_description: Custom addons for Oxigen Salud.
 repo_name: Oxigen Salud Odoo Addons

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -9,6 +10,10 @@ on:
       - "18.0"
       - "18.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
@@ -16,7 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - "18.0"
       - "18.0-ocabot-*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
@@ -65,6 +69,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,4 +81,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
-        if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}
+        if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'oxigensalud' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,12 +38,17 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:
       - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: b89f767503be6ab2b11e4f50a7557cb20066e667
+    rev: 31bdbd8e4cb94be6534f0e82b1cafb84a455f671
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,13 @@ repos:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
-        args: ["https://github.com/OCA/oxigen.odo-adodns"]
+        args: ["https://github.com/oxigensalud/odoo-addons"]
       - id: oca-gen-addon-readme
         args:
           - --addons-dir=.
           - --branch=18.0
-          - --org-name=OCA
-          - --repo-name=oxigen.odo-adodns
+          - --org-name=oxigensalud
+          - --repo-name=odoo-addons
           - --if-source-changed
           - --keep-source-digest
           - --convert-fragments-to-markdown

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=NuoBiT Solutions SL
@@ -41,6 +44,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -99,22 +103,22 @@ enable=anomalous-backslash-in-string,
     translation-positional-used,
     website-manifest-key-not-valid-uri,
     external-request-timeout,
-    # messages that do not cause the lint step to fail
-    consider-merging-classes-inherited,
+    missing-manifest-dependency,
+    too-complex,
     create-user-wo-reset-password,
     dangerous-filter-wo-user,
-    deprecated-module,
     file-not-used,
-    invalid-commit,
-    missing-manifest-dependency,
     missing-newline-extrafiles,
-    missing-readme,
     no-utf8-coding-comment,
-    odoo-addons-relative-import,
     old-api7-method-defined,
-    redefined-builtin,
-    too-complex,
     unnecessary-utf8-coding-comment,
+    # messages that do not cause the lint step to fail
+    consider-merging-classes-inherited,
+    deprecated-module,
+    invalid-commit,
+    missing-readme,
+    odoo-addons-relative-import,
+    redefined-builtin,
     manifest-external-assets
 
 

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -3,6 +3,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4
+
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest-required-authors=NuoBiT Solutions SL
@@ -33,6 +36,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Oxigen Salud Odoo Addons
 <!-- /!\ Non OCA Context : Set here the badge of your runbot / runboat instance. -->
 [![Pre-commit Status](https://github.com/oxigensalud/odoo-addons/actions/workflows/pre-commit.yml/badge.svg?branch=18.0)](https://github.com/oxigensalud/odoo-addons/actions/workflows/pre-commit.yml?query=branch%3A18.0)
-[![Build Status](https://github.com/oxigensalud/odoo-addons/actions/workflows/test.yml/badge.svg?branch=18.0)](https://github.com/oxigensaldu/odoo-addons/actions/workflows/test.yml?query=branch%3A18.0)
+[![Build Status](https://github.com/oxigensalud/odoo-addons/actions/workflows/test.yml/badge.svg?branch=18.0)](https://github.com/oxigensalud/odoo-addons/actions/workflows/test.yml?query=branch%3A18.0)
 [![codecov](https://codecov.io/gh/oxigensalud/odoo-addons/branch/18.0/graph/badge.svg)](https://codecov.io/gh/oxigensalud/odoo-addons)
 
 <!-- /!\ do not modify above this line -->

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+
+
+# Oxigen Salud Odoo Addons
+<!-- /!\ Non OCA Context : Set here the badge of your runbot / runboat instance. -->
 [![Pre-commit Status](https://github.com/oxigensalud/odoo-addons/actions/workflows/pre-commit.yml/badge.svg?branch=18.0)](https://github.com/oxigensalud/odoo-addons/actions/workflows/pre-commit.yml?query=branch%3A18.0)
 [![Build Status](https://github.com/oxigensalud/odoo-addons/actions/workflows/test.yml/badge.svg?branch=18.0)](https://github.com/oxigensaldu/odoo-addons/actions/workflows/test.yml?query=branch%3A18.0)
 [![codecov](https://codecov.io/gh/oxigensalud/odoo-addons/branch/18.0/graph/badge.svg)](https://codecov.io/gh/oxigensalud/odoo-addons)
 
 <!-- /!\ do not modify above this line -->
-
-# Oxigen Salud Odoo Addons
 
 Custom addons for Oxigen Salud.
 

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,5 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*
+    WARNING.* Missing widget: res_partner_many2one for field of type many2one.*

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "baseBranchPatterns": ["19.0", "18.0", "17.0", "16.0", "15.0"],
+  "enabledManagers": ["copier"]
+}


### PR DESCRIPTION
Update the OCA addons repo template from v1.35 to v1.44, and restore the template-rendered org/repo values that the 18.0 branch bootstrap left mangled.

**Commit 1 — `[IMP] update copier template`** (raw copier diff):
- workflow concurrency groups with in-progress cancellation
- Python 3.12 with pip caching on the pre-commit job
- JS-test screenshot upload on failure
- obsolete-dotfiles guard and oca-hooks bump in the pre-commit config
- pylintrc refresh (deprecated-modules block, message reclassification)
- checklog-odoo config tweaks
- renovate.json for copier-managed template updates
- README title block

**Commit 2 — `[FIX] restore template-rendered org and repo values`**: the bootstrap left hand-mangled values in four render spots (`oca-fix-manifest-website` argument and `oca-gen-addon-readme` org/repo arguments pointing at `OCA/oxigen.odo-adodns`, the makepot owner guard comparing against `OCA`, and a `oxigensaldu` typo in the Build Status badge link). `copier update` preserves local divergences by design, so these are restored by hand to match `.copier-answers.yml`, which was correct all along. The wrong website argument is what stamped the mangled URL into ported module manifests via pre-commit; each open port branch gets re-fixed by its own routine pre-commit run once this lands.