### PR TITLE
[FIX] connector_oxigesti_spms: import only verified orders

### DIFF
--- a/connector_oxigesti_spms/models/sale_order/adapter.py
+++ b/connector_oxigesti_spms/models/sale_order/adapter.py
@@ -19,6 +19,7 @@ class OxigestiSPMSSaleOrderAdapter(Component):
        f."Fecha_Modifica",
        f."Invoice_Id"
         FROM dbo.Odoo_SPMS_Facturas f
+        WHERE f."Odoo_Verificado" = 1
     """
 
     _sql_update = """UPDATE c


### PR DESCRIPTION
## What

Add `WHERE f."Odoo_Verificado" = 1` to the sale-order header read SQL of `connector_oxigesti_spms`, mirroring `connector_oxigesti` and `connector_ambugest`.

## Why

Oxigesti generates the monthly SPMS batch in two phases: headers first, lines afterwards (observed delay between a few seconds and 35 minutes). When the 10-minute import cron read in between, half-written orders raised *"Sale order has no lines"*, the queue job failed terminally with frozen arguments, and the incremental watermark never picked them up again (6 orders lost in the July 2026 batch, 31 in May, 34 on the first August attempt).

Oxigesti has added the `Odoo_Verificado` bit column to `Odoo_SPMS_Facturas` (2026-08-06) and will set it to 1 only once the header and all its lines are completely written, the same convention as the other two connectors. With this filter the import only ever sees finished orders and the race disappears by design.

## Validation

- Composed SQL (the framework's CTE wrapper `with t as (...) select ... from t where <domain>`) tested read-only against production MSSQL: with the filter and all rows currently at 0 it returns 0 rows; without it, 406 (all rows). Syntax and identifier quoting OK.
- Read-by-id of an unverified row now returns "missing in backend", so a half-written order can never be imported (fail-safe).
- Export paths (`_sql_update`) untouched.
- `pre-commit` clean.

Note: the filter becomes effective when Oxigesti's generation process actually sets the flag (confirmation requested). Until then imports are a no-op, which is safe: no new batches are expected before September and all current rows are already imported.